### PR TITLE
update github workflow with latest ruby setup

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,9 +21,10 @@ jobs:
           sudo apt-get -yqq install libpq-dev
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.x
+          bundler-cache: true
 
       - name: Build and test with Rake
         env: 


### PR DESCRIPTION
actions/setup-ruby@v1 is deprecated and ruby/setup-ruby@v1 is recommended.

refer here for info: [https://github.com/actions/setup-ruby](https://github.com/actions/setup-ruby)