### PR TITLE
Reintroduce semantic release workflow on pull request close

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release


### PR DESCRIPTION
Ideally, we would be able to run this workflow
only when a pull request gets merged. Unfortunately,
github does not allow us to filter specifically for
merges, so this is as close as we can get.